### PR TITLE
Feature/sup 596 typescript update directory sync app to

### DIFF
--- a/typescript-directory-sync-example/README.md
+++ b/typescript-directory-sync-example/README.md
@@ -1,6 +1,6 @@
 # TypeScript Example App with Directory Sync powered by WorkOS
 
-An example application demonstrating to use TypeScript with the [WorkOS Node SDK](https://github.com/workos/workos-node) to power Directory Sync. 
+An example application demonstrating to use TypeScript with the [WorkOS Node SDK](https://github.com/workos/workos-node) to power Directory Sync.
 
 ## Prerequisites
 
@@ -9,10 +9,12 @@ Node.js version 10+
 ## Node Project Setup
 
 1. Clone the main repo and install dependencies for the app you'd like to use:
+
     ```bash
     # HTTPS
     git clone https://github.com/workos/typescript-example-applications.git
     ```
+
     or
 
     ```bash
@@ -20,28 +22,28 @@ Node.js version 10+
     git clone git@github.com:workos/typescript-example-applications.git
     ```
 
-2. Navigate to Directory Sync app within the cloned repo. 
-   ```bash
-   $ cd typescript-example-applications/typescript-directory-sync-example
-   ```
+2. Navigate to Directory Sync app within the cloned repo.
 
-3. Install the dependencies. 
+    ```bash
+    $ cd typescript-example-applications/typescript-directory-sync-example
+    ```
+
+3. Install the dependencies.
     ```bash
     $ npm install
     ```
-
 
 ## Configure your environment
 
 1. Grab your [API Key](https://dashboard.workos.com/api-keys).
 2. Get your [Client ID](https://dashboard.workos.com/sso/configuration).
 3. Create a `.env` file at the root of the project and populate with the
-following environment variables (using values found above):
+   following environment variables (using values found above):
 
 ```typescript
-WORKOS_API_KEY=your_api_key_here
-WORKOS_CLIENT_ID=your_project_id_here
-PORT=3000
+WORKOS_API_KEY = your_api_key_here
+WORKOS_CLIENT_ID = your_project_id_here
+PORT = 8000
 ```
 
 ## Run the server
@@ -50,12 +52,11 @@ PORT=3000
 npm run dev
 ```
 
-Head to `http://localhost:3000/` to navigate your directories!
+Head to `http://localhost:8000/` to navigate your directories!
 
 ## Testing Webhooks
 
 ### 1. Click on the "Test Webhooks" button to navigate to the webhooks view.
-
 
 ### 2. Start an `ngrok` session
 
@@ -82,7 +83,6 @@ Then populate the following environment variable in your `.env` file at the root
 ```sh
 WORKOS_WEBHOOK_SECRET=your_webhook_secret
 ```
-
 
 ## Need help?
 

--- a/typescript-directory-sync-example/dist/index.js
+++ b/typescript-directory-sync-example/dist/index.js
@@ -54,10 +54,11 @@ app.get('/directory/:id', (req, res) => __awaiter(void 0, void 0, void 0, functi
         title: "Directory"
     });
 }));
+// const clientID: string = process.env.WORKOS_CLIENT_ID !== undefined ? process.env.WORKOS_CLIENT_ID : ""
 app.post('/webhooks', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
     const webhook = workos.webhooks.constructEvent({
         payload: req.body,
-        sigHeader: req.headers['workos-signature'],
+        sigHeader: req.headers['workos-signature'] !== undefined ? req.headers['workos-signature'] : "",
         secret: process.env.WORKOS_WEBHOOK_SECRET,
         tolerance: 90000,
     });

--- a/typescript-directory-sync-example/dist/index.js
+++ b/typescript-directory-sync-example/dist/index.js
@@ -13,12 +13,11 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = __importDefault(require("express"));
-const dotenv_1 = __importDefault(require("dotenv"));
-const socket_io_1 = require("socket.io");
+require("dotenv/config");
 const node_1 = require("@workos-inc/node");
+const socket_io_1 = require("socket.io");
 const morgan_1 = __importDefault(require("morgan"));
 process.on('unhandledRejection', (reason, p) => { throw reason; });
-dotenv_1.default.config();
 const app = (0, express_1.default)();
 const port = process.env.PORT || '8000';
 const workos = new node_1.WorkOS(process.env.WORKOS_API_KEY);
@@ -54,12 +53,11 @@ app.get('/directory/:id', (req, res) => __awaiter(void 0, void 0, void 0, functi
         title: "Directory"
     });
 }));
-// const clientID: string = process.env.WORKOS_CLIENT_ID !== undefined ? process.env.WORKOS_CLIENT_ID : ""
 app.post('/webhooks', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
     const webhook = workos.webhooks.constructEvent({
         payload: req.body,
-        sigHeader: req.headers['workos-signature'] !== undefined ? req.headers['workos-signature'] : "",
-        secret: process.env.WORKOS_WEBHOOK_SECRET,
+        sigHeader: typeof req.headers['workos-signature'] === 'string' ? req.headers['workos-signature'] : "",
+        secret: process.env.WORKOS_WEBHOOK_SECRET !== undefined ? process.env.WORKOS_WEBHOOK_SECRET : "",
         tolerance: 90000,
     });
     io.emit('webhook event', { webhook });

--- a/typescript-directory-sync-example/dist/index.js
+++ b/typescript-directory-sync-example/dist/index.js
@@ -14,29 +14,23 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = __importDefault(require("express"));
 const dotenv_1 = __importDefault(require("dotenv"));
-const path = require("path");
-const WorkOS = require('@workos-inc/node').default;
-var cookieParser = require('cookie-parser');
-var logger = require('morgan');
+const socket_io_1 = require("socket.io");
+const node_1 = require("@workos-inc/node");
+const morgan_1 = __importDefault(require("morgan"));
 process.on('unhandledRejection', (reason, p) => { throw reason; });
 dotenv_1.default.config();
 const app = (0, express_1.default)();
-const port = process.env.PORT;
-const workos = new WorkOS(process.env.WORKOS_API_KEY);
+const port = process.env.PORT || '8000';
+const workos = new node_1.WorkOS(process.env.WORKOS_API_KEY);
+app.use('/public', express_1.default.static('public'));
+app.use(express_1.default.urlencoded({ extended: true }));
+app.set('view engine', 'ejs');
+app.use(express_1.default.json());
+app.use((0, morgan_1.default)('dev'));
 const server = app.listen(port, () => {
     console.log(`⚡️[server]: Server is running at https://localhost:${port}`);
 });
-const io = require('socket.io')(server);
-// app.engine('html', require('ejs').renderFile);
-app.set('views', './views');
-app.set('view engine', 'ejs');
-app.use(express_1.default.static(path.join(__dirname, "public")));
-app.use(logger('dev'));
-app.use(express_1.default.json());
-app.use(express_1.default.urlencoded({ extended: false }));
-app.use(cookieParser());
-app.use(express_1.default.static(path.join(__dirname)));
-app.use('/public', express_1.default.static('public'));
+const io = new socket_io_1.Server(server);
 io.on('connection', (socket) => {
     console.log('connected');
     socket.on('disconnect', () => {
@@ -68,7 +62,7 @@ app.post('/webhooks', (req, res) => __awaiter(void 0, void 0, void 0, function* 
         tolerance: 90000,
     });
     io.emit('webhook event', { webhook });
-    return 200;
+    res.sendStatus(200);
 }));
 app.get('/webhooks', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
     res.render('webhooks.ejs', {

--- a/typescript-directory-sync-example/index.ts
+++ b/typescript-directory-sync-example/index.ts
@@ -1,36 +1,25 @@
-import express, { Express, Request, Response } from 'express';
-import dotenv from 'dotenv';
-import { Socket } from 'socket.io';
-import { Directory, Group, User } from '@workos-inc/node';
-const path = require("path");
-const WorkOS = require('@workos-inc/node').default;
-var cookieParser = require('cookie-parser');
-var logger = require('morgan');
+import express, { Express } from 'express'
+import dotenv from 'dotenv'
+import { Server, Socket } from 'socket.io'
+import { WorkOS, Directory, Group, User } from '@workos-inc/node'
+import morgan from 'morgan'
 process.on('unhandledRejection', (reason, p) => { throw reason });
 dotenv.config();
-
 const app: Express = express();
-const port = process.env.PORT;
-const workos = new WorkOS(process.env.WORKOS_API_KEY);
+const port = process.env.PORT || '8000'
+const workos = new WorkOS(process.env.WORKOS_API_KEY)
+
+app.use('/public', express.static('public'))
+app.use(express.urlencoded({ extended: true }))
+app.set('view engine', 'ejs');
+app.use(express.json())
+app.use(morgan('dev'))
 
 const server = app.listen(port, () => {
     console.log(`⚡️[server]: Server is running at https://localhost:${port}`);
 });
 
-const io = require('socket.io')(server);
-
-
-// app.engine('html', require('ejs').renderFile);
-app.set('views', './views');
-app.set('view engine', 'ejs');
-app.use(express.static(path.join(__dirname, "public")));
-
-app.use(logger('dev'));
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
-app.use(cookieParser());
-app.use(express.static(path.join(__dirname)));
-app.use('/public', express.static('public'));
+const io = new Server(server)
 
 io.on('connection', (socket: Socket) => {
     console.log('connected');
@@ -47,7 +36,6 @@ app.get("/", async (req, res) => {
         directories: directories.data
     });
 });
-
 
 app.get('/directory/:id', async (req, res) => {
     const directories = await workos.directorySync.listDirectories();
@@ -69,7 +57,7 @@ app.post('/webhooks', async (req, res) => {
     })
     io.emit('webhook event', { webhook })
 
-    return 200;
+    res.sendStatus(200)
 })
 
 app.get('/webhooks', async (req, res) => {

--- a/typescript-directory-sync-example/index.ts
+++ b/typescript-directory-sync-example/index.ts
@@ -48,11 +48,13 @@ app.get('/directory/:id', async (req, res) => {
     })
 })
 
+// const clientID: string = process.env.WORKOS_CLIENT_ID !== undefined ? process.env.WORKOS_CLIENT_ID : ""
+
 app.post('/webhooks', async (req, res) => {
     const webhook = workos.webhooks.constructEvent({
         payload: req.body,
-        sigHeader: req.headers['workos-signature'],
-        secret: process.env.WORKOS_WEBHOOK_SECRET,
+        sigHeader: typeof req.headers['workos-signature'] === 'string' ? req.headers['workos-signature'] : "",
+        secret: process.env.WORKOS_WEBHOOK_SECRET !== undefined ? process.env.WORKOS_WEBHOOK_SECRET : "",
         tolerance: 90000,
     })
     io.emit('webhook event', { webhook })

--- a/typescript-directory-sync-example/index.ts
+++ b/typescript-directory-sync-example/index.ts
@@ -1,10 +1,10 @@
 import express, { Express } from 'express'
-import dotenv from 'dotenv'
-import { Server, Socket } from 'socket.io'
+import 'dotenv/config'
 import { WorkOS, Directory, Group, User } from '@workos-inc/node'
+import { Server, Socket } from 'socket.io'
 import morgan from 'morgan'
 process.on('unhandledRejection', (reason, p) => { throw reason });
-dotenv.config();
+
 const app: Express = express();
 const port = process.env.PORT || '8000'
 const workos = new WorkOS(process.env.WORKOS_API_KEY)
@@ -47,8 +47,6 @@ app.get('/directory/:id', async (req, res) => {
         title: "Directory"
     })
 })
-
-// const clientID: string = process.env.WORKOS_CLIENT_ID !== undefined ? process.env.WORKOS_CLIENT_ID : ""
 
 app.post('/webhooks', async (req, res) => {
     const webhook = workos.webhooks.constructEvent({

--- a/typescript-directory-sync-example/package-lock.json
+++ b/typescript-directory-sync-example/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
+        "@types/morgan": "^1.9.3",
         "@types/node": "^18.0.4",
         "concurrently": "^7.2.2",
         "nodemon": "^2.0.19",
@@ -73,9 +74,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.29",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
-      "integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
+      "version": "4.17.30",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
+      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -89,10 +90,19 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
+    "node_modules/@types/morgan": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.3.tgz",
+      "integrity": "sha512-BiLcfVqGBZCyNCnCH3F4o2GmDLrpy0HeBVnNlyZG4fo88ZiE9SoiBe3C+2ezuwbjlEyT+PDZ17//TAlRxAn75Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
-      "version": "18.0.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.4.tgz",
-      "integrity": "sha512-M0+G6V0Y4YV8cqzHssZpaNCqvYwlCiulmm0PwpNLF55r/+cT8Ol42CHRU1SEaYFH2rTwiiE1aYg/2g2rrtGdPA=="
+      "version": "18.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
+      "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -117,9 +127,9 @@
       }
     },
     "node_modules/@workos-inc/node": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-2.9.0.tgz",
-      "integrity": "sha512-7k6bsx7C7Js447kxXgsh48gB5/AKFi24/3511Otk9O2UsubgaBdxVNzDLro/4IPLPwhIaCvEOBOyyx86wpnYkQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-2.11.0.tgz",
+      "integrity": "sha512-eRsT5G68ZOkXBQ+CKEjI452I2x+7SSpzGruXNJoTfi/Btxa+UqabvcGUzksE2+Q3oIQhL0/pbbJWoHFY3/eArg==",
       "dependencies": {
         "axios": "0.21.4",
         "pluralize": "8.0.0",
@@ -391,9 +401,9 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/concurrently": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.2.2.tgz",
-      "integrity": "sha512-DcQkI0ruil5BA/g7Xy3EWySGrFJovF5RYAYxwGvv9Jf9q9B1v3jPFP2tl6axExNf1qgF30kjoNYrangZ0ey4Aw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.3.0.tgz",
+      "integrity": "sha512-IiDwm+8DOcFEInca494A8V402tNTQlJaYq78RF2rijOrKEk/AOHTxhN4U1cp7GYKYX5Q6Ymh1dLTBlzIMN0ikA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -433,9 +443,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -450,14 +460,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/cookie-parser/node_modules/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
@@ -478,9 +480,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.1.tgz",
+      "integrity": "sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw==",
       "dev": true,
       "engines": {
         "node": ">=0.11"
@@ -592,14 +594,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/engine.io/node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/engine.io/node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -682,6 +676,14 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/filelist": {
@@ -1865,9 +1867,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.29",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
-      "integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
+      "version": "4.17.30",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
+      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -1881,10 +1883,19 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
+    "@types/morgan": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.3.tgz",
+      "integrity": "sha512-BiLcfVqGBZCyNCnCH3F4o2GmDLrpy0HeBVnNlyZG4fo88ZiE9SoiBe3C+2ezuwbjlEyT+PDZ17//TAlRxAn75Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
-      "version": "18.0.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.4.tgz",
-      "integrity": "sha512-M0+G6V0Y4YV8cqzHssZpaNCqvYwlCiulmm0PwpNLF55r/+cT8Ol42CHRU1SEaYFH2rTwiiE1aYg/2g2rrtGdPA=="
+      "version": "18.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
+      "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -1909,9 +1920,9 @@
       }
     },
     "@workos-inc/node": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-2.9.0.tgz",
-      "integrity": "sha512-7k6bsx7C7Js447kxXgsh48gB5/AKFi24/3511Otk9O2UsubgaBdxVNzDLro/4IPLPwhIaCvEOBOyyx86wpnYkQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-2.11.0.tgz",
+      "integrity": "sha512-eRsT5G68ZOkXBQ+CKEjI452I2x+7SSpzGruXNJoTfi/Btxa+UqabvcGUzksE2+Q3oIQhL0/pbbJWoHFY3/eArg==",
       "requires": {
         "axios": "0.21.4",
         "pluralize": "8.0.0",
@@ -2127,9 +2138,9 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "concurrently": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.2.2.tgz",
-      "integrity": "sha512-DcQkI0ruil5BA/g7Xy3EWySGrFJovF5RYAYxwGvv9Jf9q9B1v3jPFP2tl6axExNf1qgF30kjoNYrangZ0ey4Aw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.3.0.tgz",
+      "integrity": "sha512-IiDwm+8DOcFEInca494A8V402tNTQlJaYq78RF2rijOrKEk/AOHTxhN4U1cp7GYKYX5Q6Ymh1dLTBlzIMN0ikA==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -2157,9 +2168,9 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "cookie-parser": {
       "version": "1.4.6",
@@ -2168,13 +2179,6 @@
       "requires": {
         "cookie": "0.4.1",
         "cookie-signature": "1.0.6"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
-        }
       }
     },
     "cookie-signature": {
@@ -2192,9 +2196,9 @@
       }
     },
     "date-fns": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.1.tgz",
+      "integrity": "sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw==",
       "dev": true
     },
     "debug": {
@@ -2266,11 +2270,6 @@
         "ws": "~8.2.3"
       },
       "dependencies": {
-        "cookie": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
-        },
         "debug": {
           "version": "4.3.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -2343,6 +2342,13 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+        }
       }
     },
     "filelist": {

--- a/typescript-directory-sync-example/package.json
+++ b/typescript-directory-sync-example/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
+    "@types/morgan": "^1.9.3",
     "@types/node": "^18.0.4",
     "concurrently": "^7.2.2",
     "nodemon": "^2.0.19",

--- a/typescript-directory-sync-example/public/stylesheets/style.css
+++ b/typescript-directory-sync-example/public/stylesheets/style.css
@@ -132,7 +132,7 @@ body {
     border: 2px solid #6363f1;
     border-radius: 26px;
     color: white;
-    padding: 16px 32px;
+    padding: 8px 16px;
     text-align: center;
     text-decoration: none;
     display: inline-block;

--- a/typescript-directory-sync-example/views/webhooks.ejs
+++ b/typescript-directory-sync-example/views/webhooks.ejs
@@ -11,7 +11,7 @@
                 <img src="/public/images/workos_logo_new.png" alt="workos logo">
             </div>
             <div class="flex">
-                <p>WorkOSp</p>
+                <p>WorkOS</p>
             </div>
         </div>
         <div>
@@ -54,6 +54,9 @@
                 </div>
                 <div id="clear_button" class="hidden">
                     <a href="/webhooks" class="button button-sm button-outline">Clear</a>
+                </div>
+                <div id="clear_button" class="hidden">
+                    <a href="javascript:history.back()"><button class='button button-sm button-outline'>Back</button></a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Changes made:

- Remaining CommonJS syntax (require) replaced with ES6 imports
- Remaining var replaced with let and const
- Type checks added for signHeader and secret properties in webhook payload
- 'return 200 replaced' with 'res.sendStatus(200)' in webhooks endpoint so it returns 200OK response to WorkOS (with 'return 200' all webhook events were failing in WorkOS dashboard because WorkOS was never receiving a 200OK response back)
- Back button added to webhooks page
- Port in readme changed from 3000 to 8000